### PR TITLE
feat(ctf): add osint challenge category

### DIFF
--- a/ovisbot/extensions/ctf/ctf.py
+++ b/ovisbot/extensions/ctf/ctf.py
@@ -55,6 +55,7 @@ CHALLENGE_CATEGORIES = [
     "reverse",
     "stego",
     "forensics",
+    "osint",
     "htb",
 ]
 


### PR DESCRIPTION
Lots of CTFs have an OSINT category which we currently track under "misc". 

This PR adds OSINT as its own category.